### PR TITLE
Make the view template path copyable like every other source

### DIFF
--- a/resources/views/livewire/sections/views.blade.php
+++ b/resources/views/livewire/sections/views.blade.php
@@ -245,7 +245,18 @@
                                 class="ndb:space-y-4 ndb:border-l-0 ndb:bg-transparent ndb:p-4"
                             >
                                 <x-newdebugbar::inspector-source-fact label="Render source">
-                                    <x-slot:value x-text="selectedViewRender.source_label ?? 'Template source was not captured.'"></x-slot:value>
+                                    <x-slot:value>
+                                        <x-newdebugbar::inspector-source-link
+                                            data-ndb-view-copy-source
+                                            aria-label="Copy template path"
+                                            x-show.important="selectedViewRender.source_label"
+                                            ::title="selectedViewRender.source_label"
+                                            @click="copyText(selectedViewRender.source_label)"
+                                        >
+                                            <x-slot:value x-text="selectedViewRender.source_label"></x-slot:value>
+                                        </x-newdebugbar::inspector-source-link>
+                                        <span x-show.important="! selectedViewRender.source_label">Template source was not captured.</span>
+                                    </x-slot:value>
                                 </x-newdebugbar::inspector-source-fact>
 
                                 <template x-if="selectedViewRender.composers.length > 0">


### PR DESCRIPTION
Every source path in the inspector is copyable except one. Logs, Events, Cache, Exceptions and the stack frames all render their file and line through the shared source link, so you can click a path and paste it straight into an editor or a chat. The Views screen shows its render source as plain text, so the one path you most often want while chasing a template bug is the one you have to select by hand.

This renders the Views render source through that same shared source link. Clicking the path copies the file and line, exactly as it already works everywhere else. Nothing else on the screen changes, and the "Template source was not captured." message still appears when there is no source.

The closest existing example is the application call site in the log detail, which this now matches.

It is a one file change. The package suite passes, and I also ran the Views, Logs, Mail and Notifications browser tests because they share the source fact component.
