### PR TITLE
Stop view redaction from rendering Blade components

### DIFF
--- a/src/Support/Redactor.php
+++ b/src/Support/Redactor.php
@@ -4,6 +4,8 @@ namespace NewDebugBar\Support;
 
 use BackedEnum;
 use DateTimeInterface;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\View\InvokableComponentVariable;
 use Stringable;
 use UnitEnum;
 
@@ -80,6 +82,10 @@ final class Redactor
         }
 
         if ($value instanceof Stringable) {
+            if ($this->rendersWhenStringified($value)) {
+                return '['.$value::class.']';
+            }
+
             return $this->clean((string) $value, $depth, $key);
         }
 
@@ -166,6 +172,12 @@ final class Redactor
         ) ?? $value;
 
         return mb_strlen($value) > 250 ? mb_substr($value, 0, 249).'…' : $value;
+    }
+
+    private function rendersWhenStringified(object $value): bool
+    {
+        return $value instanceof Renderable
+            || $value instanceof InvokableComponentVariable;
     }
 
     private function isSensitive(string $key): bool

--- a/tests/Feature/ViewCollectorSlotTest.php
+++ b/tests/Feature/ViewCollectorSlotTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+use NewDebugBar\Http\Middleware\ProfileRequest;
+use NewDebugBar\Storage\ProfileStore;
+use NewDebugBar\Tests\Fixtures\Components\ProfiledSlotHost;
+use NewDebugBar\Tests\Fixtures\Components\ProfiledSlotIcon;
+
+it('renders class components that collect named slots while views are profiled', function () {
+    Blade::component('profiled-slot-host', ProfiledSlotHost::class);
+    Blade::component('profiled-slot-icon', ProfiledSlotIcon::class);
+
+    Route::middleware(ProfileRequest::class)->get('/profiled-slot-component', function () {
+        return response(
+            '<!doctype html><html><body>'.Blade::render('<x-profiled-slot-host />').'</body></html>',
+        );
+    });
+
+    $response = $this->get('/profiled-slot-component')->assertOk();
+
+    expect($response->getContent())
+        ->toContain('data-testid="profiled-slot-host"')
+        ->toContain('data-testid="profiled-slot-icon"')
+        ->and(app(ProfileStore::class)->get($response->headers->get('X-NewDebugBar-Profile'))['sections']['views']['summary']['count'])
+        ->toBeGreaterThan(0);
+});

--- a/tests/Fixtures/Components/ProfiledSlotHost.php
+++ b/tests/Fixtures/Components/ProfiledSlotHost.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace NewDebugBar\Tests\Fixtures\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/** Host component whose Blade view opens a named slot around a nested class component. */
+final class ProfiledSlotHost extends Component
+{
+    public function blade(): View
+    {
+        return view('profiled-slot-host');
+    }
+
+    public function render(): View
+    {
+        return $this->blade();
+    }
+}

--- a/tests/Fixtures/Components/ProfiledSlotIcon.php
+++ b/tests/Fixtures/Components/ProfiledSlotIcon.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace NewDebugBar\Tests\Fixtures\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/** Nested class component whose public blade() method is bound into view data. */
+final class ProfiledSlotIcon extends Component
+{
+    public function blade(): View
+    {
+        return view('profiled-slot-icon');
+    }
+
+    public function classes(): array
+    {
+        return ['ndb-profiled-slot-icon'];
+    }
+
+    public function render(): View
+    {
+        return $this->blade();
+    }
+}

--- a/tests/Fixtures/views/components/profiled-slot-frame.blade.php
+++ b/tests/Fixtures/views/components/profiled-slot-frame.blade.php
@@ -1,0 +1,1 @@
+<div data-testid="profiled-slot-frame">{{ $suffix }}</div>

--- a/tests/Fixtures/views/profiled-slot-host.blade.php
+++ b/tests/Fixtures/views/profiled-slot-host.blade.php
@@ -1,0 +1,7 @@
+<div data-testid="profiled-slot-host">
+    <x-dynamic-component component="profiled-slot-frame">
+        <x-slot:suffix>
+            <x-profiled-slot-icon />
+        </x-slot:suffix>
+    </x-dynamic-component>
+</div>

--- a/tests/Fixtures/views/profiled-slot-icon.blade.php
+++ b/tests/Fixtures/views/profiled-slot-icon.blade.php
@@ -1,0 +1,2 @@
+@php($customization = $classes())
+<span data-testid="profiled-slot-icon" @class($customization)>icon</span>

--- a/tests/Unit/RedactorTest.php
+++ b/tests/Unit/RedactorTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Renderable;
+use Illuminate\View\InvokableComponentVariable;
 use NewDebugBar\Support\Redactor;
 
 enum RedactorBackedValue: string
@@ -79,6 +82,42 @@ it('normalizes common debug values without leaking object internals', function (
     } finally {
         fclose($resource);
     }
+});
+
+it('does not stringify view objects that render when cast to string', function () {
+    $invoked = false;
+    $invokable = new InvokableComponentVariable(function () use (&$invoked) {
+        $invoked = true;
+
+        throw new RuntimeException('Blade view methods must not run during redaction.');
+    });
+    $view = new class implements Htmlable, Renderable, Stringable
+    {
+        public function toHtml(): string
+        {
+            throw new RuntimeException('Views must not render during redaction.');
+        }
+
+        public function render(): string
+        {
+            return $this->toHtml();
+        }
+
+        public function __toString(): string
+        {
+            return $this->toHtml();
+        }
+    };
+
+    expect((new Redactor)->clean([
+        'blade' => $invokable,
+        'view' => $view,
+        'label' => 'Context view',
+    ]))->toBe([
+        'blade' => '['.InvokableComponentVariable::class.']',
+        'view' => '['.$view::class.']',
+        'label' => 'Context view',
+    ])->and($invoked)->toBeFalse();
 });
 
 it('uses an explicit safety policy for positional query bindings', function () {


### PR DESCRIPTION
Fixes #9.

The view collector copies `$view->getData()` and runs it through `Redactor::clean()`. That path treated every `Stringable` as safe to cast. Laravel class components put public zero-argument methods (including TallStackUI's `blade()`) into view data as `InvokableComponentVariable`. Casting those to string re-renders the template while a parent named slot is still open, so `endSlot()` blows up with `array_pop(null)`.

This keeps inert stringables as strings and replaces renderable view objects with a class label. Scalar view data is unchanged.

## Tests
- Unit: `InvokableComponentVariable` and `Renderable` views are not invoked during redaction
- Feature: a class component with a named slot around a nested class component renders 200 while views are being profiled